### PR TITLE
chore: add write-gcm installation option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ git clone this-git-repo roles/stackdriver
 Requirements
 ------------
 
-The agent must be configured with an API key, which you can create by signing
-into the [Stackdriver](http://www.stackdriver.com/) web console and looking for
-the "API Keys" tab in your account settings.
+The Google Cloud monitoring API must be enabled.
 
 Role Variables
 --------------
 
-You must provide the API key in your playbook:
-
+[Google recommended authentication method](https://cloud.google.com/monitoring/agent/install-agent#linux-install): use the equivalent of the --write-gcm installation option by defining the following variable in your playbook (the default value is `true`):
 ```
-stackdriver_api_key: "REQUIRED"
+stackdriver_use_gcm: true
+```
+
+Legacy authentication method: provide stackdriver API key in your playbook:
+```
+stackdriver_api_key: "API_KEY"
 ```
 
 By default, no plugins are enabled, in which case the agent will only monitor

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,10 @@
 # Please refer to ../README.md for more information about configuring the
 # various plugins.
 
+### stackdriver agent installation options
+
+stackdriver_use_gcm: true
+
 ### apache
 
 stackdriver_apache_enabled: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,8 +15,10 @@
 - name: restart collectd
   service: name={{ stackdriver_collectd_service }} state=restarted
 
-- name: restart extractor
-  service: name={{ stackdriver_extractor_service }} state=restarted
+- name: restart extractor if not using gcm
+  service:
+    name: "{{ stackdriver_extractor_service }}"
+    state: "{% if stackdriver_use_gcm %}stopped{% else %}restarted{% endif %}"
 
 - name: stackdriver updated
   sudo: no

--- a/tasks/configure-agent.yml
+++ b/tasks/configure-agent.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Configure the agent with the Stackdriver API key.
+- name: Configure the agent.
   template: src=stackdriver.sysconfig dest={{ stackdriver_sysconfig }} backup=yes
   notify:
     - restart collectd

--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -20,7 +20,7 @@
     src: "{{ item }}.conf"
     dest: "{{ stackdriver_collectd_config_dir }}/{{ item }}.conf"
     validate: "{{ stackdriver_collectd_binary }} -tC %s"
-  with_items: '{{ stackdriver_enabled_plugins }}'
+  with_items: "{{ stackdriver_enabled_plugins }}"
   when: item != ""
   notify:
     - restart collectd
@@ -33,7 +33,7 @@
 
 - name: Remove unmanaged files if requested.
   file: path={{ stackdriver_collectd_config_dir }}/{{ item }} state=absent
-  with_items: '{{ contents.stdout_lines }}'
+  with_items: "{{ contents.stdout_lines }}"
   when: >
     stackdriver_remove_unmanaged and (
       not (item.endswith('.conf') and item != '.conf') or

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- include: configure-api-key.yml
+- include: configure-agent.yml
 
 - include: configure-plugins.yml
 
 - name: Ensure collectd is running.
   service: name={{ stackdriver_collectd_service }} state=started enabled=yes
 
-- name: Ensure extractor is running.
-  service: name={{ stackdriver_extractor_service }} state=started enabled=yes
+- name: Ensure extractor is running if not using gcm
+  service:
+    name: "{{ stackdriver_extractor_service }}"
+    state: "{% if stackdriver_use_gcm %}stopped{% else %}started{% endif %}"
+    enabled: "{% if stackdriver_use_gcm %}no{% else %}yes{% endif %}"
 
-- name: Determine the Stackdriver host ID for reporting.
+- name: Determine the Stackdriver host ID for reporting if not using gcm
   action: stackdriver_facts
+  when: not stackdriver_use_gcm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Check that the Stackdriver API key has been specified.
+- name: Check that the Stackdriver API key has been specified if not using gcm.
   fail: msg="Please provide your Stackdriver API key in the variable stackdriver_api_key."
-  when: stackdriver_api_key is not defined or not stackdriver_api_key
+  when: (stackdriver_use_gcm is not defined and stackdriver_use_gcm) and (stackdriver_api_key is not defined or not stackdriver_api_key)
 
 - name: Include OS-specific variables.
   include_vars: "{{ item }}"

--- a/templates/stackdriver.sysconfig
+++ b/templates/stackdriver.sysconfig
@@ -4,5 +4,7 @@ AUTOGENERATE_COLLECTD_CONFIG="yes"
 # url to a proxy for outbound https
 PROXY_URL=""
 
-# your stackdriver api key
-STACKDRIVER_API_KEY="{{ stackdriver_api_key }}"
+# your stackdriver api key if not using gcm
+STACKDRIVER_API_KEY="{% if stackdriver_api_key is defined %}stackdriver_api_key{% endif %}"
+
+DETECT_GCM="{% if stackdriver_use_gcm %}yes{% else %}no{% endif %}"


### PR DESCRIPTION
The agent can be installed using --write-gcm installation option as recommended in the g[oogle documentation](https://cloud.google.com/monitoring/agent/install-agent#linux-install). The legacy installation method using a stackdriver api key is still supported by the role.