### PR TITLE
fixup! chore: add write-gcm installation option support

### DIFF
--- a/tasks/configure-agent.yml
+++ b/tasks/configure-agent.yml
@@ -16,5 +16,5 @@
   template: src=stackdriver.sysconfig dest={{ stackdriver_sysconfig }} backup=yes
   notify:
     - restart collectd
-    - restart extractor
+    - restart extractor if not using gcm
     - stackdriver updated


### PR DESCRIPTION
Unable to autosquash the fixup after the first commit because the branch has already been merged into the master and a release has been created.