### PR TITLE
fix: use `become` instead of `sudo`

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,7 @@
   when: stackdriver_enabled
 
 - name: stackdriver updated
-  sudo: no
+  become: False
   local_action:
     module: stackdriver
     event: annotation

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,5 +43,5 @@
 # Post-everything diagnostics
 
 - include: diagnostics.yml
-  sudo: no
+  become: False
   when: ansible_os_family != "Windows"


### PR DESCRIPTION
## Description

Use `become` instead of `sudo`

## Test

Build and deploy a new image.